### PR TITLE
fix: prevent layout shift from HyperText scramble animation on mobile

### DIFF
--- a/src/components/HyperText.astro
+++ b/src/components/HyperText.astro
@@ -34,12 +34,27 @@ const chars = [...text];
   data-char-set={characterSet}
   aria-label={text}
 >
-  {chars.map((char, i) => (
-    <span data-char={char} data-index={i} aria-hidden="true">
-      {char}
-    </span>
-  ))}
+  <span class="hyper-text-ghost" aria-hidden="true">{text}</span>
+  <span class="hyper-text-scramble" aria-hidden="true">
+    {chars.map((char, i) => (
+      <span data-char={char} data-index={i}>{char}</span>
+    ))}
+  </span>
 </Tag>
+
+<style>
+  .hyper-text {
+    position: relative;
+    display: block;
+  }
+  .hyper-text-ghost {
+    visibility: hidden;
+  }
+  .hyper-text-scramble {
+    position: absolute;
+    inset: 0;
+  }
+</style>
 
 <script>
   function scramble(el: Element) {
@@ -56,9 +71,10 @@ const chars = [...text];
       const progress = Math.min(elapsed / duration, 1);
 
       spans.forEach((span, i) => {
+        const original = chars[i];
         const charRevealProgress = i / chars.length;
-        if (progress >= charRevealProgress) {
-          span.textContent = chars[i];
+        if (progress >= charRevealProgress || /\s/.test(original)) {
+          span.textContent = original;
         } else {
           span.textContent = charSet[Math.floor(Math.random() * charSet.length)];
         }


### PR DESCRIPTION
Render the final text as an invisible ghost that reserves the heading's
layout, overlay the absolutely-positioned scramble on top, and keep
whitespace characters intact during the scramble so line wrapping stays
consistent. Without this, replacing spaces with random letters made the
title an unbreakable word, shifting the paragraph and avatar below.