### PR TITLE
Update GitHub Actions workflow dependencies to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     name: Build & validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Uses the version pinned in package.json's `packageManager` field.
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflow dependencies to their latest major versions to ensure compatibility and access to the latest features and security updates.

## Key Changes
- `actions/checkout`: v4 → v7
- `pnpm/action-setup`: v4 → v6
- `actions/setup-node`: v4 → v6

## Details
These version bumps align the CI workflow with the latest stable releases of these GitHub Actions. The updates maintain compatibility with the existing workflow configuration, including the Node.js version (22) and pnpm cache settings.

https://claude.ai/code/session_012Z9mA35pkdp6GatKNnZXAM